### PR TITLE
update: method query is changed, and added argument on some functions

### DIFF
--- a/src/filter.ts
+++ b/src/filter.ts
@@ -7,20 +7,32 @@ export class Filter {
         return this._filter;
     }
 
-    to(address: string) {
-        this._filter += `({to} == '${address}')`;
+    to(address: string, eq: boolean = true) {
+        if (eq) {
+            this._filter += `({to} == '${address}')`;
+        } else {
+            this._filter += `({to} IN ${address})`;
+        }
         this._valid = true;
         return this;
     }
 
-    from(address: string) {
-        this._filter += `({from} == '${address}')`;
+    from(address: string, eq: boolean = true) {
+        if (eq) {
+            this._filter += `({from} == '${address}')`;
+        } else {
+            this._filter += `({from} IN ${address})`;
+        }
         this._valid = true;
         return this;
     }
 
-    method(methodId: string) {
-        this._filter += `({methodId} == '${methodId}')`;
+    method(methodId: string, eq: boolean = true) {
+        if (eq) {
+            this._filter += `({method_id} == '${methodId}')`;
+        } else {
+            this._filter += `({method_id} IN ${methodId})`;
+        }
         this._valid = true;
         return this;
     }


### PR DESCRIPTION
Test : 
```nodejs
const newF = new Filter()
    .to(`['0x0000000000000000000000000000000000000000', '0x0000000000000000000000000000000000000001', '0x0000000000000000000000000000000000000002']`, false)
    .and.from(`['0x0000000000000000000000000000000000000000', '0x0000000000000000000000000000000000000001', '0x0000000000000000000000000000000000000002']`, false)
    .and.method('0x1111')
    .or.to('0x0000000000000000000000000000000000000004')
console.log(newF)
```

`({to} IN ['0x0000000000000000000000000000000000000000', '0x0000000000000000000000000000000000000001', '0x0000000000000000000000000000000000000002']) AND ({from} IN ['0x0000000000000000000000000000000000000000', '0x0000000000000000000000000000000000000001', '0x0000000000000000000000000000000000000002']) AND ({method_id} == '0x1111') OR ({to} == '0x0000000000000000000000000000000000000004')`

Sometimes i need with the query 'IN' on filter, maybe this can be checked and considered. 
I ask the discussion group, they (dev team) say : 

`It should be "method_id" instead of "methodId": https://docs.bloxroute.com/streams/newtxs-and-pendingtxs/filter#examples-1`

*This clarify for changing the method_id.

CMIIW, just doin what i do for my project.